### PR TITLE
Add comprehensive Jest and Playwright tests

### DIFF
--- a/app/lib/__tests__/localMemoStorage.test.ts
+++ b/app/lib/__tests__/localMemoStorage.test.ts
@@ -1,0 +1,69 @@
+import { LocalMemoStorage } from '../local-memo-storage';
+
+describe('LocalMemoStorage', () => {
+  const createStorage = () => {
+    let store: Record<string, string> = {};
+    (global as any).localStorage = {
+      getItem: (key: string) => store[key] || null,
+      setItem: (key: string, value: string) => {
+        store[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      clear: () => {
+        store = {};
+      },
+      key: (_: number) => null,
+      length: 0,
+    };
+  };
+
+  beforeEach(() => {
+    createStorage();
+  });
+
+  test('save and retrieve memos', () => {
+    const memo = LocalMemoStorage.saveMemo({
+      title: 'title',
+      content: 'content',
+      tags: ['tag1'],
+      isPrivate: false,
+      userId: 'user1',
+    });
+    const all = LocalMemoStorage.getAllMemos();
+    expect(all).toHaveLength(1);
+    expect(all[0].id).toBe(memo.id);
+  });
+
+  test('update and delete memo with branches', () => {
+    const memo = LocalMemoStorage.saveMemo({
+      title: 't',
+      content: 'c',
+      tags: [],
+      isPrivate: false,
+      userId: 'u1',
+    });
+    const updated = LocalMemoStorage.updateMemo(memo.id, { title: 'new' });
+    expect(updated?.title).toBe('new');
+    const missing = LocalMemoStorage.updateMemo('missing', { title: 'x' });
+    expect(missing).toBeNull();
+    expect(LocalMemoStorage.deleteMemo('missing')).toBe(false);
+    expect(LocalMemoStorage.deleteMemo(memo.id)).toBe(true);
+  });
+
+  test('getMemosByUserId and searchMemos', () => {
+    LocalMemoStorage.saveMemo({ title: 'hello', content: 'world', tags: ['tag1'], isPrivate: false, userId: 'u1' });
+    LocalMemoStorage.saveMemo({ title: 'another', content: 'note', tags: ['tag2'], isPrivate: false, userId: 'u2' });
+    expect(LocalMemoStorage.getMemosByUserId('u1')).toHaveLength(1);
+    expect(LocalMemoStorage.searchMemos('hello')).toHaveLength(1);
+    expect(LocalMemoStorage.searchMemos('tag2')).toHaveLength(1);
+    expect(LocalMemoStorage.searchMemos('note', 'u2')).toHaveLength(1);
+  });
+
+  test('getAllMemos handles invalid JSON gracefully', () => {
+    (global as any).localStorage.setItem('notetree_memos', 'invalid-json');
+    const memos = LocalMemoStorage.getAllMemos();
+    expect(memos).toEqual([]);
+  });
+});

--- a/app/lib/__tests__/security.test.ts
+++ b/app/lib/__tests__/security.test.ts
@@ -1,0 +1,143 @@
+import {
+  sanitizeHtml,
+  validators,
+  validateURL,
+  generateCSPHeader,
+  filterXSS,
+  checkPasswordStrength,
+  sanitizeInput,
+  detectXSS,
+  detectSQLInjection,
+  validateSessionToken,
+  validatePasswordStrength,
+  generateCSRFToken,
+  validateCSRFToken,
+  rateLimiter,
+  generateSecureRandomString,
+  validateFileUpload,
+  getSecurityHeaders
+} from '../security';
+
+describe('security utilities', () => {
+  test('sanitizeHtml removes unsafe tags', () => {
+    const dirty = '<p>ok</p><script>alert(1)</script>';
+    expect(sanitizeHtml(dirty)).toBe('<p>ok</p>');
+  });
+
+  test('validators.email', () => {
+    expect(validators.email('test@example.com').valid).toBe(true);
+    expect(validators.email('bad').valid).toBe(false);
+    expect(validators.email('a'.repeat(255)+'@a.com').valid).toBe(false);
+  });
+
+  test('validators.textLength', () => {
+    expect(validators.textLength('abc', 2, 4).valid).toBe(true);
+    expect(validators.textLength('a', 2, 4).valid).toBe(false);
+    expect(validators.textLength('aaaaa', 2, 4).valid).toBe(false);
+  });
+
+  test('validators.tag', () => {
+    expect(validators.tag('tag').valid).toBe(true);
+    expect(validators.tag('').valid).toBe(false);
+    expect(validators.tag('x'.repeat(51)).valid).toBe(false);
+    expect(validators.tag('<bad>').valid).toBe(false);
+  });
+
+  test('validators.noInjection', () => {
+    expect(validators.noInjection('SELECT * FROM users').valid).toBe(false);
+    expect(validators.noInjection('safe').valid).toBe(true);
+  });
+
+  test('validators.fileName', () => {
+    expect(validators.fileName('file.txt').valid).toBe(true);
+    expect(validators.fileName('').valid).toBe(false);
+    expect(validators.fileName('bad?name').valid).toBe(false);
+  });
+
+  test('validators.password', () => {
+    expect(validators.password('12345').valid).toBe(false);
+    expect(validators.password('123456').valid).toBe(true);
+    expect(validators.password('a'.repeat(129)).valid).toBe(false);
+  });
+
+  test('validators.username', () => {
+    expect(validators.username('user_name').valid).toBe(true);
+    expect(validators.username('').valid).toBe(false);
+    expect(validators.username('a').valid).toBe(false);
+    expect(validators.username('user!').valid).toBe(false);
+    expect(validators.username('ab___c').valid).toBe(false);
+  });
+
+  test('validateURL enforces https and external', () => {
+    expect(validateURL('https://example.com').valid).toBe(true);
+    expect(validateURL('http://example.com').valid).toBe(false);
+    expect(validateURL('https://localhost').valid).toBe(false);
+    expect(validateURL('notaurl').valid).toBe(false);
+  });
+
+  test('generateCSPHeader returns policy string', () => {
+    const header = generateCSPHeader();
+    expect(header).toContain("default-src 'self'");
+  });
+
+  test('filterXSS strips dangerous content', () => {
+    const result = filterXSS('<img src="javascript:alert(1)" onerror="do()">');
+    expect(result).not.toMatch(/<|javascript:|onerror/);
+  });
+
+  test('checkPasswordStrength evaluates password', () => {
+    const weak = checkPasswordStrength('abc');
+    expect(weak.isValid).toBe(false);
+    const strong = checkPasswordStrength('Aa1!aaaa');
+    expect(strong.isValid).toBe(true);
+  });
+
+  test('sanitizeInput escapes HTML entities', () => {
+    expect(sanitizeInput('<div>')).toBe('&lt;div&gt;');
+    expect(sanitizeInput((null as unknown) as any)).toBe('');
+  });
+
+  test('detectXSS and detectSQLInjection', () => {
+    expect(detectXSS('<script>alert(1)</script>')).toBe(true);
+    expect(detectXSS('safe')).toBe(false);
+    expect(detectSQLInjection('SELECT * FROM users')).toBe(true);
+    expect(detectSQLInjection('hello')).toBe(false);
+  });
+
+  test('validateSessionToken and validatePasswordStrength', () => {
+    const token = 'a.b.c';
+    expect(validateSessionToken(token)).toBe(true);
+    expect(validateSessionToken('bad token')).toBe(false);
+    const strong = validatePasswordStrength('Aa1!aaaa');
+    expect(strong.isValid).toBe(true);
+    const weak = validatePasswordStrength('short');
+    expect(weak.isValid).toBe(false);
+  });
+
+  test('generate and validate CSRF token', () => {
+    const token = generateCSRFToken();
+    expect(token).toHaveLength(64);
+    expect(validateCSRFToken(token, token)).toBe(true);
+    expect(validateCSRFToken(token, 'other')).toBe(false);
+  });
+
+  test('rate limiter and secure random string', () => {
+    const limiter = new (rateLimiter.constructor as any)(2, 1000);
+    expect(limiter.isAllowed('id')).toBe(true);
+    expect(limiter.isAllowed('id')).toBe(true);
+    expect(limiter.isAllowed('id')).toBe(false);
+    const rand = generateSecureRandomString(10);
+    expect(rand).toHaveLength(10);
+  });
+
+  test('validate file upload and headers', () => {
+    const file = new File(['hi'], 'test.txt', { type: 'text/plain' });
+    expect(validateFileUpload(file).isValid).toBe(true);
+    const bigFile = new File([new Uint8Array(11 * 1024 * 1024)], 'big.png', { type: 'image/png' });
+    expect(validateFileUpload(bigFile).isValid).toBe(false);
+    const badType = new File(['hi'], 'bad.exe', { type: 'application/x-msdownload' });
+    expect(validateFileUpload(badType).isValid).toBe(false);
+    const headers = getSecurityHeaders();
+    expect(headers['X-Frame-Options']).toBe('DENY');
+  });
+});

--- a/app/lib/__tests__/utils.test.ts
+++ b/app/lib/__tests__/utils.test.ts
@@ -1,0 +1,7 @@
+import { cn } from '../utils';
+
+describe('cn utility', () => {
+  test('merges class names correctly', () => {
+    expect(cn('a', false && 'b', 'c')).toBe('a c');
+  });
+});

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+
+test('shows login form when unauthenticated', async ({ page }) => {
+  await page.route('**/api/auth/me', route => route.fulfill({ status: 401, body: JSON.stringify({ success: false }) }));
+  await page.goto('/');
+  await expect(page.getByLabel('メールアドレス')).toBeVisible();
+});
+
+test('login form accepts input', async ({ page }) => {
+  await page.route('**/api/auth/me', route => route.fulfill({ status: 401, body: JSON.stringify({ success: false }) }));
+  await page.goto('/');
+  await page.getByLabel('メールアドレス').fill('user@example.com');
+  await page.getByLabel('パスワード').fill('password');
+  await expect(page.getByLabel('メールアドレス')).toHaveValue('user@example.com');
+});
+
+test('can switch to sign up form', async ({ page }) => {
+  await page.route('**/api/auth/me', route => route.fulfill({ status: 401, body: JSON.stringify({ success: false }) }));
+  await page.goto('/');
+  await page.getByRole('button', { name: 'サインアップ' }).click();
+  await expect(page.getByLabel('ユーザー名')).toBeVisible();
+});
+
+test('sign up form accepts input', async ({ page }) => {
+  await page.route('**/api/auth/me', route => route.fulfill({ status: 401, body: JSON.stringify({ success: false }) }));
+  await page.goto('/');
+  await page.getByRole('button', { name: 'サインアップ' }).click();
+  await page.getByLabel('ユーザー名').fill('tester');
+  await expect(page.getByLabel('ユーザー名')).toHaveValue('tester');
+});
+
+test('successful login shows memo app', async ({ page }) => {
+  let loggedIn = false;
+  await page.route('**/api/auth/me', route => {
+    if (loggedIn) {
+      route.fulfill({ status: 200, body: JSON.stringify({ success: true, data: { id: '1', email: 'user@example.com' } }) });
+    } else {
+      route.fulfill({ status: 401, body: JSON.stringify({ success: false }) });
+    }
+  });
+  await page.route('**/api/auth/login', route => {
+    loggedIn = true;
+    route.fulfill({ status: 200, body: JSON.stringify({ success: true }) });
+  });
+  await page.route('**/api/**', route => {
+    if (route.request().url().includes('/api/auth/')) return route.fallback();
+    route.fulfill({ status: 200, body: JSON.stringify({ success: true, data: [] }) });
+  });
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+  await page.getByLabel('メールアドレス').fill('user@example.com');
+  await page.getByLabel('パスワード').fill('password');
+  await page.locator('form').getByRole('button', { name: /ログイン/ }).click({ force: true });
+  await expect(page.getByRole('button', { name: '新しいメモを作成' })).toBeVisible();
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,12 +1,26 @@
-const nextJest = require('next/jest')();
+const nextJest = require('next/jest')({ dir: './' });
 
 module.exports = nextJest({
   testEnvironment: 'jest-environment-jsdom',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/app/$1',
-    // serverやappのエイリアスは使われていないため削除
   },
   transform: {
     '^.+\\.(t|j)sx?$': ['@swc/jest'],
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  collectCoverageFrom: [
+    'app/lib/local-memo-storage.ts',
+    'app/lib/security.ts',
+    'app/lib/utils.ts'
+  ],
+  testPathIgnorePatterns: ['<rootDir>/e2e/'],
+  coverageThreshold: {
+    global: {
+      statements: 90,
+      branches: 80,
+      functions: 90,
+      lines: 90,
+    },
   },
 });

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -44,7 +44,7 @@ Object.defineProperty(performance, 'memory', {
 // Mock next/headers for server-side functions like cookies()
 jest.mock('next/headers', () => ({
   cookies: jest.fn(() => ({
-    get: jest.fn((name: string) => {
+    get: jest.fn((name) => {
       // Return a mock cookie value based on name, or null
       if (name === 'auth_token') {
         return { value: 'mock-auth-token' };

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "uuid": "^11.1.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.55.0",
         "@swc/jest": "^0.2.39",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
@@ -55,6 +56,7 @@
         "jest": "^30.0.5",
         "jest-environment-jsdom": "^30.0.5",
         "tailwindcss": "^3.4.15",
+        "ts-jest": "^29.4.1",
         "typescript": "^5.8.3"
       }
     },
@@ -2201,6 +2203,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@prisma/client": {
@@ -4858,6 +4876,19 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -7196,6 +7227,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -9378,6 +9431,13 @@
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -9449,6 +9509,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -9606,6 +9673,13 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
     },
@@ -10279,6 +10353,53 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -12041,6 +12162,72 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-jest": {
+      "version": "29.4.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.1.tgz",
+      "integrity": "sha512-SaeUtjfpg9Uqu8IbeDKtdaS0g8lS6FT6OzM3ezrDfErPJPHNDo/Ey+VFGP1bQIDfagYDLyRpd7O15XpG1Es2Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.8",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.2",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -12209,6 +12396,20 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -12585,6 +12786,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest",
+    "test": "jest --runInBand",
     "test:watch": "jest --watch",
-    "test:cov": "jest --coverage"
+    "test:cov": "jest --coverage",
+    "test:e2e": "playwright test",
+    "test:all": "npm run test && npm run test:e2e"
   },
   "dependencies": {
     "@prisma/client": "^6.13.0",
@@ -43,6 +45,7 @@
     "uuid": "^11.1.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.0",
     "@swc/jest": "^0.2.39",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
@@ -59,6 +62,7 @@
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.0.5",
     "tailwindcss": "^3.4.15",
+    "ts-jest": "^29.4.1",
     "typescript": "^5.8.3"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  reporter: 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:5174',
+    headless: true,
+  },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://127.0.0.1:5174',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+    env: {
+      NEXT_PUBLIC_API_URL: 'http://127.0.0.1:5174',
+      NEXT_PUBLIC_WS_URL: 'ws://127.0.0.1:3001',
+      JWT_SECRET: 'test',
+      DATABASE_URL: 'postgresql://user:pass@localhost:5432/db',
+      NEXT_PUBLIC_ENABLE_MOCK: 'true',
+      INTERNAL_API_TOKEN: 'test',
+    },
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+});

--- a/test_log.md
+++ b/test_log.md
@@ -50,3 +50,9 @@
 2. フォーム送信後の画面遷移確認
 3. ログイン機能のテスト
 
+
+## 3. 自動テスト結果
+
+- `npm run test:cov`
+- `npm run test:e2e`
+- `npm run test:all`


### PR DESCRIPTION
## Summary
- configure Jest with SWC and coverage thresholds
- add unit tests for local memo storage and security utilities
- implement Playwright authentication flow tests

## Testing
- `npm run test:cov`
- `npm run test:e2e`
- `npm run test:all`


------
https://chatgpt.com/codex/tasks/task_e_68ac8c94c5e4832881dbbdf75253abff